### PR TITLE
Ensure gh api is authenticated when deleting preview environment

### DIFF
--- a/.github/workflows/delete-preview-environment.yml
+++ b/.github/workflows/delete-preview-environment.yml
@@ -16,6 +16,7 @@ jobs:
     steps:
       - name: Delete Preview Environment
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ENVIRONMENT_NAME: preview-${{ github.event.pull_request.number }}
         run: |
           echo "Deleting environment: $ENVIRONMENT_NAME"


### PR DESCRIPTION
Ensure the workflow authenticates with `GH_TOKEN` when calling `gh api` to delete the preview environment.